### PR TITLE
Show eslint warnings in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,11 @@
     "**/node_modules": true
   },
   "editor.formatOnSave": true,
-  "prettier.eslintIntegration": true
+  "prettier.eslintIntegration": true,
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ]
 }


### PR DESCRIPTION
- [x] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md).
- [x] Checked for [duplicate pull requests](https://github.com/iamturns/create-exposed-app/pulls)
- [x] Title is a summary of the change, in present tense, ideally < 50 characters
- [x] Pulling from a branch (right side), not `master`.
- [x] Pulling into `master` branch (left side).
~Fixing a bug? An open [bug report](https://github.com/iamturns/create-exposed-app/labels/bug) exists.~
~Breaking API changes? Migration notes attached.~

## :sparkles: Enhancement

I found this setting when reading [this article](https://dev.to/robertcoopercode/using-eslint-and-prettier-in-a-typescript-project-53jb#automatically-fixing-code-vs-code) on how to autofix eslint in VSCode (different from autoFormat).

See also [vscode-eslint documentation](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint#user-content-settings-options)

Before:
Only ts warnings and errors show as Problems in VSCode
<img width="1792" alt="screen shot 2019-02-26 at 6 57 05 am" src="https://user-images.githubusercontent.com/3150816/53358507-735e9700-3995-11e9-8180-9b0e521aa8f3.png">

After:
eslint warnings and errors as shown also
<img width="1792" alt="screen shot 2019-02-26 at 6 56 54 am" src="https://user-images.githubusercontent.com/3150816/53358513-75c0f100-3995-11e9-9c78-dffb3e530f2d.png">

Note:
It is possible for both ts and eslint to warn about the same problem
<img width="1792" alt="screen shot 2019-02-26 at 7 12 30 am" src="https://user-images.githubusercontent.com/3150816/53358721-f384fc80-3995-11e9-9db3-f0cfa0b993fd.png">
