### PR TITLE
Allow headings in markdown files to end with exclamation mark

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -5,4 +5,4 @@ line-length: false
 
 no-trailing-punctuation:
   # Allow headings to end with question mark for FAQ
-  punctuation: ".,;:!"
+  punctuation: ".,;:"

--- a/templates/.markdownlint.yml.template
+++ b/templates/.markdownlint.yml.template
@@ -5,4 +5,4 @@ line-length: false
 
 no-trailing-punctuation:
   # Allow headings to end with question mark for FAQ
-  punctuation: ".,;:!"
+  punctuation: ".,;:"


### PR DESCRIPTION
# :sparkles: Enhancement

Allow headings in markdown files to end with exclamation mark

## Checklist

<!--
Thanks for contributing!
Put an x in the checklist boxes that apply: [X]. You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md).
- [x] Checked for [duplicate pull requests](https://github.com/iamturns/create-exposed-app/pulls)
- [x] Title is a summary of the change, in present tense, ideally < 50 characters
- [x] Pulling from a branch (right side), not `master`.
- [x] Pulling into `master` branch (left side).
- ~Fixing a bug? An open [bug report](https://github.com/iamturns/create-exposed-app/labels/bug) exists.~
- ~Breaking API changes? Migration notes attached.~

