### PR TITLE
Improve github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,13 +1,27 @@
 <!--
 Thanks for contributing!
-Put an x in the checklist boxes that apply: [X]. You can also fill these out after creating the PR.
-If you're unsure about any of them, don't hesitate to ask. We're here to help!
+-->
+
+# :page_with_curl: Issue
+
+Describe your issue here.
+
+## :white_check_mark: Checklist
+
+<!--
+Put an `x` in the checklist boxes to ackknowledge: `[x]`.
+If an item does not apply: remove the `[ ]`, and surround the remaining text with `~` on each side.
+
+Example:
+
+- [x] This item is ackknowledged
+- ~This item does not apply~
+
+Feel free to submit and complete the items later.
+If you're unsure about any of these items, don't hesitate to ask. We're here to help!
 -->
 
 - [ ] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md).
 - [ ] Checked for [duplicate issues](https://github.com/iamturns/create-exposed-app/issues).
 - [ ] Title is a summary of the issue, in present tense, and ideally < 50 characters
-
-## Issue
-
-Describe your issue here.
+- [ ] Ready for review

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -7,19 +7,13 @@ assignees: iamturns
 
 <!--
 Thanks for contributing!
-Put an x in the checklist boxes that apply: [X]. You can also fill these out after creating the PR.
-If you're unsure about any of them, don't hesitate to ask. We're here to help!
 -->
 
-- [ ] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md).
-- [ ] Checked for [duplicate bug reports](https://github.com/iamturns/create-exposed-app/issues?q=label%3Abug).
-- [ ] Title is a summary of the bug report, in present tense, and ideally < 50 characters
-
-## Bug report
+# :bug: Bug report
 
 Introduce the bug with a summary.
 
-### Steps to reproduce
+## Steps to reproduce
 
 1. ...
 2. ...
@@ -27,29 +21,45 @@ Introduce the bug with a summary.
 
 Please include if possible and/or relevant: code, config, links, repository that reproduces the bug.
 
-### Expected behavior
+## Expected behavior
 
 What should happen?
 
-### Actual behaviour
+## Actual behaviour
 
 What happens instead? Please include if possible and/or relevant: error messages, stack traces, logs, screenshots.
 
-### Environment
+## Environment
+
+<!-- Remove items that aren't relevant -->
 
 - `create-exposed-app` version: [e.g. latest]
-- Operating System and version: [e.g. macOS XX, iOS XX. See whatsmyos.com]
-- Device used: [e.g. iPhone 6, MacBook Pro]
-
-<!-- Server-side bug? Fill in details below. Othewise, remove items. -->
-
 - Node.js version:
 - npm version:
-
-<!-- Client-side bug? Fill in details below. Othewise, remove items. -->
-
+- Operating System and version: [e.g. macOS XX, iOS XX. See whatsmyos.com]
+- Device used: [e.g. iPhone 6, MacBook Pro]
 - Browser name and version: [e.g. Chrome XX, Safari XX, Android Browser XX. See whatsmybrowser.org]
 
-### Additional
+## Additional
 
 E.g. suggested solution, theories, etc.
+
+## :white_check_mark: Checklist
+
+<!--
+Put an `x` in the checklist boxes to ackknowledge: `[x]`.
+If an item does not apply: remove the `[ ]`, and surround the remaining text with `~` on each side.
+
+Example:
+
+- [x] This item is ackknowledged
+- ~This item does not apply~
+
+Feel free to submit and complete the items later.
+If you're unsure about any of these items, don't hesitate to ask. We're here to help!
+-->
+
+- [ ] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md).
+- [ ] Checked for [duplicate bug reports](https://github.com/iamturns/create-exposed-app/issues?q=label%3Abug).
+- [ ] Title is a summary of the bug report, in present tense, and ideally < 50 characters
+- [ ] Ready for review

--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT_REQUEST.md
@@ -7,15 +7,9 @@ assignees: iamturns
 
 <!--
 Thanks for contributing!
-Put an x in the checklist boxes that apply: [X]. You can also fill these out after creating the PR.
-If you're unsure about any of them, don't hesitate to ask. We're here to help!
 -->
 
-- [ ] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md).
-- [ ] Checked for [duplicate enhancements](https://github.com/iamturns/create-exposed-app/issues?q=label%3Aenhancement).
-- [ ] Title is a summary of the enhancement request, in present tense, and ideally < 50 characters
-
-## Enhancement
+# :sparkles: Enhancement Request
 
 Describe your enhancement request here. Possible details to include:
 
@@ -24,3 +18,23 @@ Describe your enhancement request here. Possible details to include:
 - How can it benefit others?
 - Possible implementation
 - Alternative changes or solutions considered
+
+## :white_check_mark: Checklist
+
+<!--
+Put an `x` in the checklist boxes to ackknowledge: `[x]`.
+If an item does not apply: remove the `[ ]`, and surround the remaining text with `~` on each side.
+
+Example:
+
+- [x] This item is ackknowledged
+- ~This item does not apply~
+
+Feel free to submit and complete the items later.
+If you're unsure about any of these items, don't hesitate to ask. We're here to help!
+-->
+
+- [ ] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md).
+- [ ] Checked for [duplicate enhancements](https://github.com/iamturns/create-exposed-app/issues?q=label%3Aenhancement).
+- [ ] Title is a summary of the enhancement request, in present tense, and ideally < 50 characters
+- [ ] Ready for review

--- a/.github/ISSUE_TEMPLATE/QUESTION.md
+++ b/.github/ISSUE_TEMPLATE/QUESTION.md
@@ -7,14 +7,28 @@ assignees: iamturns
 
 <!--
 Thanks for contributing!
-Put an x in the checklist boxes that apply: [X]. You can also fill these out after creating the PR.
-If you're unsure about any of them, don't hesitate to ask. We're here to help!
+-->
+
+# :question: Question
+
+Ask your question here.
+
+## :white_check_mark: Checklist
+
+<!--
+Put an `x` in the checklist boxes to ackknowledge: `[x]`.
+If an item does not apply: remove the `[ ]`, and surround the remaining text with `~` on each side.
+
+Example:
+
+- [x] This item is ackknowledged
+- ~This item does not apply~
+
+Feel free to submit and complete the items later.
+If you're unsure about any of these items, don't hesitate to ask. We're here to help!
 -->
 
 - [ ] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md).
 - [ ] Checked for [duplicate questions](https://github.com/iamturns/create-exposed-app/issues?q=label%3Aquestion).
 - [ ] Title is a summary of the question, in present tense, and ideally < 50 characters
-
-## Question
-
-Ask your question here.
+- [ ] Ready for review

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,12 @@
 <!--
 Thanks for contributing!
-Put an x in the checklist boxes that apply: [X]. You can also fill these out after creating the PR.
-If you're unsure about any of them, don't hesitate to ask. We're here to help!
 -->
 
-- [ ] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md).
-- [ ] Checked for [duplicate pull requests](https://github.com/iamturns/create-exposed-app/pulls)
-- [ ] Title is a summary of the change, in present tense, ideally < 50 characters
-- [ ] Pulling from a branch (right side), not `master`.
-- [ ] Pulling into `master` branch (left side).
-- [ ] Fixing a bug? An open [bug report](https://github.com/iamturns/create-exposed-app/labels/bug) exists.
-- [ ] Breaking API changes? Migration notes attached.
-
-## :bug: Bug fix
+# :bug: Bug fix
 
 ...or...
 
-## :sparkles: Enhancement
+# :sparkles: Enhancement
 
 Closes #123, #456.
 
@@ -29,3 +19,27 @@ Describe your changes here. Possible details to include:
 - Anything unusual to point out
 - Reasons for choosing this solution
 - Alternative solutions considered
+
+## :white_check_mark: Checklist
+
+<!--
+Put an `x` in the checklist boxes to ackknowledge: `[x]`.
+If an item does not apply: remove the `[ ]`, and surround the remaining text with `~` on each side.
+
+Example:
+
+- [x] This item is ackknowledged
+- ~This item does not apply~
+
+Feel free to submit and complete the items later.
+If you're unsure about any of these items, don't hesitate to ask. We're here to help!
+-->
+
+- [ ] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md).
+- [ ] Checked for [duplicate pull requests](https://github.com/iamturns/create-exposed-app/pulls)
+- [ ] Title is a summary of the change, in present tense, ideally < 50 characters
+- [ ] Pulling from a branch (right side), not `master`.
+- [ ] Pulling into `master` branch (left side).
+- [ ] Fixing a bug? An open [bug report](https://github.com/iamturns/create-exposed-app/labels/bug) exists.
+- [ ] Breaking API changes? Migration notes attached.
+- [ ] Ready for review

--- a/templates/.github/ISSUE_TEMPLATE.md.template
+++ b/templates/.github/ISSUE_TEMPLATE.md.template
@@ -1,13 +1,27 @@
 <!--
 Thanks for contributing!
-Put an x in the checklist boxes that apply: [X]. You can also fill these out after creating the PR.
-If you're unsure about any of them, don't hesitate to ask. We're here to help!
+-->
+
+# :page_with_curl: Issue
+
+Describe your issue here.
+
+## :white_check_mark: Checklist
+
+<!--
+Put an `x` in the checklist boxes to ackknowledge: `[x]`.
+If an item does not apply: remove the `[ ]`, and surround the remaining text with `~` on each side.
+
+Example:
+
+- [x] This item is ackknowledged
+- ~This item does not apply~
+
+Feel free to submit and complete the items later.
+If you're unsure about any of these items, don't hesitate to ask. We're here to help!
 -->
 
 - [ ] Following [CODE_OF_CONDUCT.md](<%- gitHubRepoUrl %>/blob/master/CODE_OF_CONDUCT.md).
 - [ ] Checked for [duplicate issues](<%- gitHubRepoUrl %>/issues).
 - [ ] Title is a summary of the issue, in present tense, and ideally < 50 characters
-
-## Issue
-
-Describe your issue here.
+- [ ] Ready for review

--- a/templates/.github/ISSUE_TEMPLATE/BUG_REPORT.md.template
+++ b/templates/.github/ISSUE_TEMPLATE/BUG_REPORT.md.template
@@ -7,19 +7,13 @@ assignees: <%- authorGitHub %>
 
 <!--
 Thanks for contributing!
-Put an x in the checklist boxes that apply: [X]. You can also fill these out after creating the PR.
-If you're unsure about any of them, don't hesitate to ask. We're here to help!
 -->
 
-- [ ] Following [CODE_OF_CONDUCT.md](<%- gitHubRepoUrl %>/blob/master/CODE_OF_CONDUCT.md).
-- [ ] Checked for [duplicate bug reports](<%- gitHubRepoUrl %>/issues?q=label%3Abug).
-- [ ] Title is a summary of the bug report, in present tense, and ideally < 50 characters
-
-## Bug report
+# :bug: Bug report
 
 Introduce the bug with a summary.
 
-### Steps to reproduce
+## Steps to reproduce
 
 1. ...
 2. ...
@@ -27,29 +21,45 @@ Introduce the bug with a summary.
 
 Please include if possible and/or relevant: code, config, links, repository that reproduces the bug.
 
-### Expected behavior
+## Expected behavior
 
 What should happen?
 
-### Actual behaviour
+## Actual behaviour
 
 What happens instead? Please include if possible and/or relevant: error messages, stack traces, logs, screenshots.
 
-### Environment
+## Environment
 
-- `<%- projectPackageName %>` version: [e.g. latest]
-- Operating System and version: [e.g. macOS XX, iOS XX. See whatsmyos.com]
-- Device used: [e.g. iPhone 6, MacBook Pro]
+<!-- Remove items that aren't relevant -->
 
-<!-- Server-side bug? Fill in details below. Othewise, remove items. -->
-
+- `create-exposed-app` version: [e.g. latest]
 - Node.js version:
 - npm version:
-
-<!-- Client-side bug? Fill in details below. Othewise, remove items. -->
-
+- Operating System and version: [e.g. macOS XX, iOS XX. See whatsmyos.com]
+- Device used: [e.g. iPhone 6, MacBook Pro]
 - Browser name and version: [e.g. Chrome XX, Safari XX, Android Browser XX. See whatsmybrowser.org]
 
-### Additional
+## Additional
 
 E.g. suggested solution, theories, etc.
+
+## :white_check_mark: Checklist
+
+<!--
+Put an `x` in the checklist boxes to ackknowledge: `[x]`.
+If an item does not apply: remove the `[ ]`, and surround the remaining text with `~` on each side.
+
+Example:
+
+- [x] This item is ackknowledged
+- ~This item does not apply~
+
+Feel free to submit and complete the items later.
+If you're unsure about any of these items, don't hesitate to ask. We're here to help!
+-->
+
+- [ ] Following [CODE_OF_CONDUCT.md](<%- gitHubRepoUrl %>/blob/master/CODE_OF_CONDUCT.md).
+- [ ] Checked for [duplicate bug reports](<%- gitHubRepoUrl %>/issues?q=label%3Abug).
+- [ ] Title is a summary of the bug report, in present tense, and ideally < 50 characters
+- [ ] Ready for review

--- a/templates/.github/ISSUE_TEMPLATE/ENHANCEMENT_REQUEST.md.template
+++ b/templates/.github/ISSUE_TEMPLATE/ENHANCEMENT_REQUEST.md.template
@@ -7,15 +7,9 @@ assignees: <%- authorGitHub %>
 
 <!--
 Thanks for contributing!
-Put an x in the checklist boxes that apply: [X]. You can also fill these out after creating the PR.
-If you're unsure about any of them, don't hesitate to ask. We're here to help!
 -->
 
-- [ ] Following [CODE_OF_CONDUCT.md](<%- gitHubRepoUrl %>/blob/master/CODE_OF_CONDUCT.md).
-- [ ] Checked for [duplicate enhancements](<%- gitHubRepoUrl %>/issues?q=label%3Aenhancement).
-- [ ] Title is a summary of the enhancement request, in present tense, and ideally < 50 characters
-
-## Enhancement
+# :sparkles: Enhancement Request
 
 Describe your enhancement request here. Possible details to include:
 
@@ -24,3 +18,23 @@ Describe your enhancement request here. Possible details to include:
 - How can it benefit others?
 - Possible implementation
 - Alternative changes or solutions considered
+
+## :white_check_mark: Checklist
+
+<!--
+Put an `x` in the checklist boxes to ackknowledge: `[x]`.
+If an item does not apply: remove the `[ ]`, and surround the remaining text with `~` on each side.
+
+Example:
+
+- [x] This item is ackknowledged
+- ~This item does not apply~
+
+Feel free to submit and complete the items later.
+If you're unsure about any of these items, don't hesitate to ask. We're here to help!
+-->
+
+- [ ] Following [CODE_OF_CONDUCT.md](<%- gitHubRepoUrl %>/blob/master/CODE_OF_CONDUCT.md).
+- [ ] Checked for [duplicate enhancements](<%- gitHubRepoUrl %>/issues?q=label%3Aenhancement).
+- [ ] Title is a summary of the enhancement request, in present tense, and ideally < 50 characters
+- [ ] Ready for review

--- a/templates/.github/ISSUE_TEMPLATE/QUESTION.md.template
+++ b/templates/.github/ISSUE_TEMPLATE/QUESTION.md.template
@@ -7,14 +7,28 @@ assignees: <%- authorGitHub %>
 
 <!--
 Thanks for contributing!
-Put an x in the checklist boxes that apply: [X]. You can also fill these out after creating the PR.
-If you're unsure about any of them, don't hesitate to ask. We're here to help!
+-->
+
+# :question: Question
+
+Ask your question here.
+
+## :white_check_mark: Checklist
+
+<!--
+Put an `x` in the checklist boxes to ackknowledge: `[x]`.
+If an item does not apply: remove the `[ ]`, and surround the remaining text with `~` on each side.
+
+Example:
+
+- [x] This item is ackknowledged
+- ~This item does not apply~
+
+Feel free to submit and complete the items later.
+If you're unsure about any of these items, don't hesitate to ask. We're here to help!
 -->
 
 - [ ] Following [CODE_OF_CONDUCT.md](<%- gitHubRepoUrl %>/blob/master/CODE_OF_CONDUCT.md).
 - [ ] Checked for [duplicate questions](<%- gitHubRepoUrl %>/issues?q=label%3Aquestion).
 - [ ] Title is a summary of the question, in present tense, and ideally < 50 characters
-
-## Question
-
-Ask your question here.
+- [ ] Ready for review

--- a/templates/.github/PULL_REQUEST_TEMPLATE.md.template
+++ b/templates/.github/PULL_REQUEST_TEMPLATE.md.template
@@ -1,22 +1,12 @@
 <!--
 Thanks for contributing!
-Put an x in the checklist boxes that apply: [X]. You can also fill these out after creating the PR.
-If you're unsure about any of them, don't hesitate to ask. We're here to help!
 -->
 
-- [ ] Following [CODE_OF_CONDUCT.md](<%- gitHubRepoUrl %>/blob/master/CODE_OF_CONDUCT.md).
-- [ ] Checked for [duplicate pull requests](<%- gitHubRepoUrl %>/pulls)
-- [ ] Title is a summary of the change, in present tense, ideally < 50 characters
-- [ ] Pulling from a branch (right side), not `master`.
-- [ ] Pulling into `master` branch (left side).
-- [ ] Fixing a bug? An open [bug report](<%- gitHubRepoUrl %>/labels/bug) exists.
-- [ ] Breaking API changes? Migration notes attached.
-
-## :bug: Bug fix
+# :bug: Bug fix
 
 ...or...
 
-## :sparkles: Enhancement
+# :sparkles: Enhancement
 
 Closes #123, #456.
 
@@ -29,3 +19,27 @@ Describe your changes here. Possible details to include:
 - Anything unusual to point out
 - Reasons for choosing this solution
 - Alternative solutions considered
+
+## :white_check_mark: Checklist
+
+<!--
+Put an `x` in the checklist boxes to ackknowledge: `[x]`.
+If an item does not apply: remove the `[ ]`, and surround the remaining text with `~` on each side.
+
+Example:
+
+- [x] This item is ackknowledged
+- ~This item does not apply~
+
+Feel free to submit and complete the items later.
+If you're unsure about any of these items, don't hesitate to ask. We're here to help!
+-->
+
+- [ ] Following [CODE_OF_CONDUCT.md](<%- gitHubRepoUrl %>/blob/master/CODE_OF_CONDUCT.md).
+- [ ] Checked for [duplicate pull requests](<%- gitHubRepoUrl %>/pulls)
+- [ ] Title is a summary of the change, in present tense, ideally < 50 characters
+- [ ] Pulling from a branch (right side), not `master`.
+- [ ] Pulling into `master` branch (left side).
+- [ ] Fixing a bug? An open [bug report](<%- gitHubRepoUrl %>/labels/bug) exists.
+- [ ] Breaking API changes? Migration notes attached.
+- [ ] Ready for review


### PR DESCRIPTION
# :sparkles: Enhancement

Closes #59.

When hovering over an issue in GitHub, the first few lines are displayed. Currently this displays the checklist. With this PR, more relevant text is displayed.

## Checklist

<!--
Thanks for contributing!
Put an x in the checklist boxes that apply: [X]. You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md).
- [x] Checked for [duplicate pull requests](https://github.com/iamturns/create-exposed-app/pulls)
- [x] Title is a summary of the change, in present tense, ideally < 50 characters
- [x] Pulling from a branch (right side), not `master`.
- [x] Pulling into `master` branch (left side).
- ~Fixing a bug? An open [bug report](https://github.com/iamturns/create-exposed-app/labels/bug) exists.~
- ~Breaking API changes? Migration notes attached.~
