### PR TITLE
Improve markdownlint and prettier integration

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,8 +1,12 @@
 default: true
 
-# Disable line length check, as some services use a linebreak-sensitive renderer, e.g. GitHub comment and BitBucket
+# Some services use a linebreak-sensitive renderer, e.g. GitHub comment and BitBucket
 line-length: false
 
 no-trailing-punctuation:
   # Allow headings to end with question mark for FAQ
   punctuation: ".,;:"
+
+# Prettier handles these:
+list-marker-space: false
+no-multiple-blanks: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,8 +12,6 @@
     "typescript",
     "typescriptreact"
   ],
-  // Prefer `markdownlint`
-  "prettier.disableLanguages": ["markdown"],
   // Run `eslint --fix` after Prettier, follows `npm run format` flow
   "prettier.eslintIntegration": true
 }

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -5,7 +5,7 @@ module.exports = {
     ".editorconfig": ["prettier --write", "git add"],
     LICENSE: ["prettier --write", "git add"],
     "**/*.md": ["markdownlint"],
-    "**/*.{css,gql,graphql,html,json,less,scss,vue,yaml,yml}": [
+    "**/*.{css,gql,graphql,html,json,less,md,mdx,scss,vue,yaml,yml}": [
       "prettier --write",
       "git add",
     ],

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "format:eslint": "eslint --cache --ext .js,.jsx,.ts,.tsx --fix ./ >/dev/null 2>&1 || true",
     "format:imports": "import-sort --write '**/*.{js,jsx,ts,tsx}'",
     "format:package": "prettier-package-json --write",
-    "format:prettier": "prettier --write '**/*.{css,gql,graphql,html,js,jsx,json,less,scss,ts,tsx,vue,yaml,yml}' '.editorconfig' 'LICENSE'",
+    "format:prettier": "prettier --write '**/*.{css,gql,graphql,html,js,jsx,json,less,md,mdx,scss,ts,tsx,vue,yaml,yml}' '.editorconfig' 'LICENSE'",
     "lint": "run-p lint:eslint lint:markdown",
     "lint:eslint": "eslint --cache --ext .js,.jsx,.ts,.tsx --format=pretty ./",
     "lint:markdown": "markdownlint --ignore coverage --ignore dist --ignore node_modules '**/*.md' '.**/**/*.md'",

--- a/templates/.markdownlint.yml.template
+++ b/templates/.markdownlint.yml.template
@@ -1,8 +1,12 @@
 default: true
 
-# Disable line length check, as some services use a linebreak-sensitive renderer, e.g. GitHub comment and BitBucket
+# Some services use a linebreak-sensitive renderer, e.g. GitHub comment and BitBucket
 line-length: false
 
 no-trailing-punctuation:
   # Allow headings to end with question mark for FAQ
   punctuation: ".,;:"
+
+# Prettier handles these:
+list-marker-space: false
+no-multiple-blanks: false

--- a/templates/.vscode/settings.json.template
+++ b/templates/.vscode/settings.json.template
@@ -12,8 +12,6 @@
     "typescript",
     "typescriptreact"
   ],
-  // Prefer `markdownlint`
-  "prettier.disableLanguages": ["markdown"],
   // Run `eslint --fix` after Prettier, follows `npm run format` flow
   "prettier.eslintIntegration": true
 }

--- a/templates/lint-staged.config.js.template
+++ b/templates/lint-staged.config.js.template
@@ -5,7 +5,7 @@ module.exports = {
     ".editorconfig": ["prettier --write", "git add"],
     LICENSE: ["prettier --write", "git add"],
     "**/*.md": ["markdownlint"],
-    "**/*.{css,gql,graphql,html,json,less,scss,vue,yaml,yml}": [
+    "**/*.{css,gql,graphql,html,json,less,md,mdx,scss,vue,yaml,yml}": [
       "prettier --write",
       "git add",
     ],

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -29,7 +29,7 @@
     "format:eslint": "eslint --cache --ext .js,.jsx,.ts,.tsx --fix ./ >/dev/null 2>&1 || true",
     "format:imports": "import-sort --write '**/*.{js,jsx,ts,tsx}'",
     "format:package": "prettier-package-json --write",
-    "format:prettier": "prettier --write '**/*.{css,gql,graphql,html,js,jsx,json,less,scss,ts,tsx,vue,yaml,yml}' '.editorconfig' 'LICENSE'",
+    "format:prettier": "prettier --write '**/*.{css,gql,graphql,html,js,jsx,json,less,md,mdx,scss,ts,tsx,vue,yaml,yml}' '.editorconfig' 'LICENSE'",
     "lint": "run-p lint:eslint lint:markdown",
     "lint:eslint": "eslint --cache --ext .js,.jsx,.ts,.tsx --format=pretty ./",
     "lint:markdown": "markdownlint --ignore coverage --ignore dist --ignore node_modules '**/*.md' '.**/**/*.md'",


### PR DESCRIPTION
<!--
Thanks for contributing!
-->

# :sparkles: Enhancement

It's better for Prettier to format and process markdown files. Markdown lint rules that do not agree with Prettier are now disabled.

---

<!--
Put an `x` in the checklist boxes to ackknowledge: `[x]`.
Feel free to submit now and complete the checklist items later.
If you're unsure about anything, don't hesitate to ask. We're here to help!
-->

:white_check_mark: **Checklist**

- [x] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md).
- [x] Checked for [duplicate pull requests](https://github.com/iamturns/create-exposed-app/pulls)
- [x] Title is a summary of the change, in present tense, ideally < 50 characters
- [x] Pulling from a branch (right side), not `master`.
- [x] Pulling into `master` branch (left side).
- [x] Fixing a bug? An open [bug report](https://github.com/iamturns/create-exposed-app/labels/bug) exists.
- [x] Breaking API changes? Migration notes attached.
- [x] Ready for review
