### PR TITLE
Lint build only when src directory changes

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -16,6 +16,10 @@ module.exports = {
       "git add",
       "jest --bail --findRelatedTests",
     ],
+    "src/**/*": [
+      // Run build without passing changed files to command: https://github.com/okonet/lint-staged/issues/174
+      "bash -c 'npm run build'",
+    ],
   },
   // The formatting tools are ordered to run sequentially
   concurrent: false,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "create-exposed-app": "dist/bin/create-exposed-app.js"
   },
   "scripts": {
-    "pre-commit": "lint-staged && npm run build",
+    "pre-commit": "lint-staged",
     "build": "run-p --print-label build:src build:dts",
     "build:dts": "tsc --emitDeclarationOnly",
     "build:dts:watch": "npm run build:dts -- --watch --preserveWatchOutput",

--- a/templates/lint-staged.config.js.template
+++ b/templates/lint-staged.config.js.template
@@ -16,6 +16,10 @@ module.exports = {
       "git add",
       "jest --bail --findRelatedTests",
     ],
+    "src/**/*": [
+      // Run build without passing changed files to command: https://github.com/okonet/lint-staged/issues/174
+      "bash -c 'npm run build'",
+    ],
   },
   // The formatting tools are ordered to run sequentially
   concurrent: false,

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -14,7 +14,7 @@
   "version": "0.0.0-development",
   "main": "dist/<%- projectPackageName %>.js",
   "scripts": {
-    "pre-commit": "lint-staged && npm run build",
+    "pre-commit": "lint-staged",
     "build": "run-p --print-label build:src build:dts",
     "build:dts": "tsc --emitDeclarationOnly",
     "build:dts:watch": "npm run build:dts -- --watch --preserveWatchOutput",


### PR DESCRIPTION
<!--
Thanks for contributing!
-->

# :sparkles: Enhancement

Currently the build is validated on each commit.

However, this can slow things down when source files are not changed.

This PR ensures the build is only validated after source files are changed.

---

:white_check_mark: Checklist

<!--
Feel free to submit now and complete the checklist items below later.
If you're unsure about anything, don't hesitate to ask. We're here to help!
-->

- [x] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md).
- [x] Checked for [duplicate pull requests](https://github.com/iamturns/create-exposed-app/pulls)
- [x] Title is a summary of the change, in present tense, ideally < 50 characters
- [x] Pulling from a branch (right side), not `master`.
- [x] Pulling into `master` branch (left side).
- [x] Changed relevant files in `templates` directory.
- [x] Fixing a bug? An open [bug report](https://github.com/iamturns/create-exposed-app/labels/bug) exists.
- [x] Breaking API changes? Migration notes attached.
- [x] Ready for review
