### PR TITLE
Rename build-serve command to start:src

### DIFF
--- a/bin/build-examples.sh
+++ b/bin/build-examples.sh
@@ -7,7 +7,7 @@ mkdir examples
 
 mkdir examples/default-server-side
 
-npm run build-serve \
+npm run start:src \
   -- \
   --project-package-name="create-exposed-app" \
   --project-overview="Default server-side example of create-exposed-app" \
@@ -34,7 +34,7 @@ rm -Rf \
 
 mkdir examples/default-client-side
 
-npm run build-serve \
+npm run start:src \
   -- \
   --project-package-name="create-exposed-app" \
   --project-overview="Default client-side example of create-exposed-app" \

--- a/examples/default-client-side/package.json
+++ b/examples/default-client-side/package.json
@@ -16,8 +16,6 @@
   "scripts": {
     "pre-commit": "lint-staged",
     "build": "run-p --print-label build:src build:dts",
-    "build-serve": "babel-node --extensions .js,.jsx,.ts,.tsx src/create-exposed-app.ts",
-    "build-serve:watch": "nodemon --ext js,jsx,ts,tsx --delay 1 --exec npm run build-serve",
     "build:dts": "tsc --emitDeclarationOnly",
     "build:dts:watch": "npm run build:dts -- --watch --preserveWatchOutput",
     "build:src": "babel src --out-dir dist --extensions .js,.jsx,.ts,.tsx --source-maps",
@@ -40,6 +38,8 @@
     "prepublish": "rimraf dist && npm run build",
     "start": "node dist/create-exposed-app.js",
     "start:dev": "NODE_ENV=development npm run start",
+    "start:src": "babel-node --extensions .js,.jsx,.ts,.tsx src/create-exposed-app-cli.ts",
+    "start:src:watch": "nodemon --ext js,jsx,ts,tsx --delay 1 --exec npm run start:src",
     "test": "jest --passWithNoTests --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc --noEmit",

--- a/examples/default-server-side/package.json
+++ b/examples/default-server-side/package.json
@@ -16,8 +16,6 @@
   "scripts": {
     "pre-commit": "lint-staged",
     "build": "run-p --print-label build:src build:dts",
-    "build-serve": "babel-node --extensions .js,.jsx,.ts,.tsx src/create-exposed-app.ts",
-    "build-serve:watch": "nodemon --ext js,jsx,ts,tsx --delay 1 --exec npm run build-serve",
     "build:dts": "tsc --emitDeclarationOnly",
     "build:dts:watch": "npm run build:dts -- --watch --preserveWatchOutput",
     "build:src": "babel src --out-dir dist --extensions .js,.jsx,.ts,.tsx --source-maps",
@@ -40,6 +38,8 @@
     "prepublish": "rimraf dist && npm run build",
     "start": "node dist/create-exposed-app.js",
     "start:dev": "NODE_ENV=development npm run start",
+    "start:src": "babel-node --extensions .js,.jsx,.ts,.tsx src/create-exposed-app-cli.ts",
+    "start:src:watch": "nodemon --ext js,jsx,ts,tsx --delay 1 --exec npm run start:src",
     "test": "jest --passWithNoTests --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
   "scripts": {
     "pre-commit": "lint-staged",
     "build": "run-p --print-label build:src build:dts",
-    "build-serve": "babel-node --extensions .js,.jsx,.ts,.tsx src/create-exposed-app-cli.ts",
-    "build-serve:watch": "nodemon --ext js,jsx,ts,tsx --delay 1 --exec npm run build-serve",
     "build:dts": "tsc --emitDeclarationOnly",
     "build:dts:watch": "npm run build:dts -- --watch --preserveWatchOutput",
     "build:examples": "bash bin/build-examples.sh",
@@ -45,6 +43,8 @@
     "prepublish": "rimraf dist && npm run build",
     "start": "node dist/create-exposed-app.js",
     "start:dev": "NODE_ENV=development npm run start",
+    "start:src": "babel-node --extensions .js,.jsx,.ts,.tsx src/create-exposed-app-cli.ts",
+    "start:src:watch": "nodemon --ext js,jsx,ts,tsx --delay 1 --exec npm run start:src",
     "test": "jest --passWithNoTests --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc --noEmit",

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -16,8 +16,6 @@
   "scripts": {
     "pre-commit": "lint-staged",
     "build": "run-p --print-label build:src build:dts",
-    "build-serve": "babel-node --extensions .js,.jsx,.ts,.tsx src/<%- projectPackageName %>.ts",
-    "build-serve:watch": "nodemon --ext js,jsx,ts,tsx --delay 1 --exec npm run build-serve",
     "build:dts": "tsc --emitDeclarationOnly",
     "build:dts:watch": "npm run build:dts -- --watch --preserveWatchOutput",
     "build:src": "babel src --out-dir dist --extensions .js,.jsx,.ts,.tsx --source-maps",
@@ -40,6 +38,8 @@
     "prepublish": "rimraf dist && npm run build",
     "start": "node dist/<%- projectPackageName %>.js",
     "start:dev": "NODE_ENV=development npm run start",
+    "start:src": "babel-node --extensions .js,.jsx,.ts,.tsx src/create-exposed-app-cli.ts",
+    "start:src:watch": "nodemon --ext js,jsx,ts,tsx --delay 1 --exec npm run start:src",
     "test": "jest --passWithNoTests --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION


<!--
Thanks for contributing!
-->

# :sparkles: Enhancement

`build-serve` implies a sever. Starting from the src directory is more generic and suitable, and so `start:src` (next to `start`) is more suitable.

BREAKING CHANGE: use `start:src` command instead of `build-serve`.
---

:white_check_mark: Checklist

<!--
Feel free to submit now and complete the checklist items below later.
If you're unsure about anything, don't hesitate to ask. We're here to help!
-->

- [x] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md).
- [x] Checked for [duplicate pull requests](https://github.com/iamturns/create-exposed-app/pulls)
- [x] Title is a summary of the change, in present tense, ideally < 50 characters
- [x] Pulling from a branch (right side), not `master`.
- [x] Pulling into `master` branch (left side).
- [x] Fixing a bug? An open [bug report](https://github.com/iamturns/create-exposed-app/labels/bug) exists.
- [x] Breaking API changes? Migration notes attached.
- [x] Changed relevant files in `templates` directory.
- [x] Updated examples: `npm run build:examples`.
- [x] Ready for review
