### PR TITLE
Separate test coverage into separate command

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
     "start--dev": "NODE_ENV=development npm run start",
     "start-src": "babel-node --extensions .js,.jsx,.ts,.tsx --require node_modules/dotenv/config src/create-exposed-app-cli.ts",
     "start-src--watch": "nodemon --ext js,jsx,ts,tsx --delay 1 --exec npm run start-src",
-    "test": "jest --passWithNoTests --coverage",
-    "test--watch": "jest --watch",
+    "test": "jest --passWithNoTests",
+    "test--coverage": "npm run test -- --coverage",
+    "test--watch": "npm run test -- --watch",
     "typecheck": "tsc --noEmit",
     "typecheck--watch": "npm run typecheck -- --watch",
     "validate": "run-p --print-label lint typecheck test build"

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -39,8 +39,9 @@
     "start--dev": "NODE_ENV=development npm run start",
     "start-src": "babel-node --extensions .js,.jsx,.ts,.tsx --require node_modules/dotenv/config src/<%- projectPackageName %>.ts",
     "start-src--watch": "nodemon --ext js,jsx,ts,tsx --delay 1 --exec npm run start-src",
-    "test": "jest --passWithNoTests --coverage",
-    "test--watch": "jest --watch",
+    "test": "jest --passWithNoTests",
+    "test--coverage": "npm run test -- --coverage",
+    "test--watch": "npm run test -- --watch",
     "typecheck": "tsc --noEmit",
     "typecheck--watch": "npm run typecheck -- --watch",
     "validate": "run-p --print-label lint typecheck test build"


### PR DESCRIPTION

<!--
Thanks for contributing!
-->

# :sparkles: Enhancement

Closes #48.

---

:white_check_mark: Checklist

<!--
Feel free to submit now and complete the checklist items below later.
If you're unsure about anything, don't hesitate to ask. We're here to help!
-->

- [x] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md)
- [x] Checked for [duplicate pull requests](https://github.com/iamturns/create-exposed-app/pulls)
- [x] Title is a summary of the change, in present tense, ideally < 50 characters
- [x] Pulling from a branch (right side), not `master`
- [x] Pulling into `master` branch (left side)
- [x] Fixing a bug? An open [bug report](https://github.com/iamturns/create-exposed-app/labels/bug) exists
- [x] Breaking API changes? Migration notes attached
- [x] Changed relevant files in `templates` directory
- [x] Ready for review
